### PR TITLE
Add  php5-xdebug to the install

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -39,6 +39,7 @@ apt_package_check_list=(
   php5-intl
   php5-gd
   php5-mcrypt
+  php5-xdebug
   php-apc
   apache2
   libapache2-mod-php5


### PR DESCRIPTION
Thanks for this vagrant - I got it up & going pretty smoothly after having to blow away my previous vagrant. I just added xdebug locally - I think it should be in the build
