### PR TITLE
Fixes to prevent errors

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -216,7 +216,7 @@ tools_install() {
 
   # nodejs
   # Install suported version of nodejs
-  curl -sL https://deb.nodesource.com/setup_7.x | bash -
+  curl -sL https://deb.nodesource.com/setup_5.x | bash -
   apt-get install -y nodejs
 
   # xdebug

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -63,6 +63,9 @@ apt_package_check_list=(
   colordiff
   patch
   postfix
+  php-pear
+  php5-dev
+  libcurl3-openssl-dev
 
   # dnsmasq to redirect *.dev to locahost
   dnsmasq
@@ -210,6 +213,11 @@ tools_install() {
   # Make sure we have the latest npm version and the update checker module
   npm install -g npm
   npm install -g npm-check-updates
+
+  # nodejs
+  # Install suported version of nodejs
+  curl -sL https://deb.nodesource.com/setup_7.x | bash -
+  apt-get install -y nodejs
 
   # xdebug
   #

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -43,7 +43,6 @@ apt_package_check_list=(
   php-apc
   apache2
   libapache2-mod-php5
-  nodejs-legacy
   npm
   phantomjs
   ruby


### PR DESCRIPTION
During provision I get errors about nodejs being unsupported which causes the provision to fail, later in the provision it reports pecl is missing.  This PR adds the following:
* Updated version of nodejs
* Packages to provide pecl