### PR TITLE
Multiple fixes

### DIFF
--- a/config/homebin/buildkit_init
+++ b/config/homebin/buildkit_init
@@ -25,6 +25,10 @@ echo "Updating buildkit and tools..."
 civi-download-tools
 
 echo "Configuring amp and civibuild..."
+if [ ! -d "/home/vagrant/.amp/log" ]; then
+  mkdir -p "/home/vagrant/.amp/log"
+fi
+
 amp config:set \
   --mysql_type="mycnf" \
   --mysql_dsn="mysql://root:root@localhost:3306" \

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -433,9 +433,6 @@ services_restart() {
   service memcached restart
   service mailcatcher restart
 
-  # Disable PHP Xdebug module by default
-  php5dismod xdebug
-
   # Enable PHP mcrypt module by default
   php5enmod mcrypt
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -220,7 +220,7 @@ tools_install() {
 
   # nodejs
   # Install suported version of nodejs
-  curl -sL https://deb.nodesource.com/setup_5.x | bash -
+  curl -sL https://deb.nodesource.com/setup_8.x | bash -
   apt-get install -y nodejs
 
   # xdebug


### PR DESCRIPTION
* This is for development, don't disable xdebug
* Switch to nodejs v8 now that shoreditch doesn't require 5.x
* Fix #18. Create amp logs directory if it doesn't exist