### PR TITLE
Switch to a base box that supports php 7.2 & remove some legacy stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ Once Vagrant and VirtualBox are installed, download or clone cividev and type `v
 Multiple projects can be developed at once in the same environment. Cividev is pre-configured with the following CiviCRM configurations:
 
 * __d7-master__ with Drupal 7 and the current development version of CiviCRM
-* __d7-46__ with Drupal 7 and CiviCRM 4.6 (LTS)
-* __wp-master__ and __wp-46__ with WordPress
+* __wp-master__ with WordPress
 * __d8-master__ with Drupal 8
 * __b-master__ with Backdrop
 
@@ -61,7 +60,7 @@ These shared directories allow you to work, for example, in `cividev/www/d7-mast
     * `git clone git://github.com/civicrm/civicrm-buildkit-vagrant.git cividev`
     * OR download and extract the repository master [zip file](https://github.com/civicrm/civicrm-buildkit-vagrant/archive/master.zip) to a `cividev` directory on your computer.
     * OR download and extract a [stable release](https://github.com/civicrm/civicrm-buildkit-vagrant/releases) zip file if you'd like some extra comfort.
-1. In a command prompt, change into the directory where you placed the files.  Use `cd` from the command prompt to do this.  
+1. In a command prompt, change into the directory where you placed the files.  Use `cd` from the command prompt to do this.
 1. Start the Vagrant environment with `vagrant up`
     * Be VERY patient as the magic happens (time for a coffee or lunch break?). This will take a while on the first run as your local machine downloads the required files and builds all.
     * Watch as the script ends, as an administrator or `su` ***password may be required*** to properly modify the hosts file on your local machine.
@@ -114,8 +113,6 @@ Cividev relies on the stability of both Vagrant and Virtualbox. These caveats ar
 
 The default memory allotment for the cividev virtual machine is 1024MB. If you would like to raise or lower this value to better match your system requirements, a [guide to changing memory size](https://github.com/Varying-Vagrant-Vagrants/VVV/wiki/Customising-your-Vagrant's-attributes-and-parameters) is in the wiki.
 
-Cividev is using a 64bit version of Ubuntu. Some older CPUs (such as the popular *Intel Core 2 Duo* series) do not support this. Changing the line `config.vm.box = "ubuntu/trusty64"` to `"ubuntu/trusty32"` in the `Vagrantfile` before `vagrant up` will provision a 32bit version of Ubuntu that will work on older hardware.
-
 ### Credentials and Such
 
 All CMS usernames and passwords for these installations are `demo / demo` and `admin / admin` by default.
@@ -132,10 +129,10 @@ Run phpunit /srv/www/d7-master/sites/all/modules/civicrm/tests/phpunit/HelloTest
 
 A bunch of stuff!
 
-1. [Ubuntu](http://www.ubuntu.com/) 14.04 LTS (Trusty Tahr)
+1. [Ubuntu](http://www.ubuntu.com/) 18.10
 1. [apache](http://apache.org/) 2.4.x
-1. [mysql](https://www.mysql.com/) 5.5.x
-1. [php5](http://php.net/) 5.5.x and all extensions needed for CiviCRM
+1. [mysql](https://www.mysql.com/) 5.7.x
+1. [php5](http://php.net/) 7.2.x and all extensions needed for CiviCRM
 1. [memcached](http://memcached.org/)
 1. PHP [memcache extension](https://pecl.php.net/package/memcache)
 1. PHP [xdebug extension](https://pecl.php.net/package/xdebug/)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,9 +63,9 @@ Vagrant.configure("2") do |config|
   # Default Ubuntu Box
   #
   # This box is provided by Ubuntu vagrantcloud.com and is a nicely sized (332MB)
-  # box containing the Ubuntu 14.04 Trusty 64 bit release. Once this box is downloaded
+  # box containing the Ubuntu 18.10 Cosmic Cuttlefish 64 bit release. Once this box is downloaded
   # to your host computer, it is cached for future use under the specified box name.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "generic/ubuntu1810"
 
   # The Parallels Provider uses a different naming scheme.
   config.vm.provider :parallels do |v, override|

--- a/config/cividev-config/index.php
+++ b/config/cividev-config/index.php
@@ -31,9 +31,7 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 	<p>Multiple projects can be developed at once in the same environment. Cividev is pre-configured with the following CiviCRM configurations:</p>
 
     <p>d7-master with Drupal 7 and the current development version of CiviCRM</br>
-    d7-46 with Drupal 7 and CiviCRM 4.6 (LTS)</br>
     wp-master with WordPress and the current development version of CiviCRM</br>
-    wp-46 with WordPress and CiviCRM 4.6 (LTS)</br>
     d8-master with Drupal 8</br>
     b-master with Backdrop</p>
 
@@ -43,9 +41,7 @@ if ( file_exists( 'dashboard-custom.php' ) ) {
 
 <ul class="nav">
 	<li><a href="http://d7-master.test/">http://d7-master.test/</a> Drupal 7 CiviCRM master (clean)</li>
-	<li><a href="http://d7-46.test/">http://d7-46.test</a> Drupal 7 CiviCRM 4.6 (clean)</li>
 	<li><a href="http://wp-master.test/">http://wp-master.test</a> WP and CiviCRM master</li>
-	<li><a href="http://wp-46.test/">http://wp-46.test</a> WP and CiviCRM 4.6</li>
 </ul>
 </body>
 </html>

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -26,29 +26,28 @@ apt_package_install_list=()
 apt_package_check_list=(
 
   # copied from https://github.com/civicrm/civicrm-buildkit/blob/master/bin/civi-download-tools#L259
-  acl
+  # acl - seems not so required in later versions
   git
   wget
-  mariadb-server
-  mariadb-client
-  php7.1-cli
-  php7.1-imap
-  php7.1-ldap
-  php7.1-curl
-  php7.1-mysql
-  php7.1-intl
-  php7.1-gd
-  php7.1-mcrypt
-  php7.1-xdebug
-  php7.1-xml
-  php7.1-mbstring
-  php7.1-bcmath
-  php7.1-soap
-  php7.1-zip
-  php7.1-imagick
-  php-apc
+  mysql-server
+  mysql-client-core-5.7
+  php7.2-cli
+  php7.2-imap
+  php7.2-ldap
+  php7.2-curl
+  php7.2-mysql
+  php7.2-intl
+  php7.2-gd
+  php-xdebug
+  php7.2-xml
+  php7.2-mbstring
+  php7.2-bcmath
+  php7.2-soap
+  php7.2-zip
+  php-imagick
+  php-apcu
   apache2
-  libapache2-mod-php7.1
+  libapache2-mod-php7.2
   phantomjs
   ruby
   ruby-dev
@@ -56,7 +55,6 @@ apt_package_check_list=(
 
   # other packages that come in handy
   imagemagick
-  subversion
   git-core
   zip
   unzip
@@ -68,7 +66,7 @@ apt_package_check_list=(
   patch
   postfix
   php-pear
-  php7.1-dev
+  php7.2-dev
   libcurl3-openssl-dev
 
   # dnsmasq to redirect *.test to locahost
@@ -156,7 +154,7 @@ profile_setup() {
 package_check() {
   # Loop through each of our packages that should be installed on the system. If
   # not yet installed, it should be added to the array of packages to install.
-  sudo apt-get install -y python-software-properties
+  sudo apt-get install -y software-properties-common
   sudo add-apt-repository -y ppa:ondrej/php
   sudo apt-get update -y
   local pkg
@@ -255,7 +253,7 @@ tools_install() {
   if [[ -n "$(composer --version --no-ansi | grep 'Composer version')" ]]; then
     echo "Updating Composer..."
     COMPOSER_HOME=/usr/local/src/composer composer self-update
-    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:4.3.*
+    COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/phpunit:>4.0
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update phpunit/php-invoker:1.1.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update mockery/mockery:0.9.*
     COMPOSER_HOME=/usr/local/src/composer composer -q global require --no-update d11wtq/boris:v1.0.8
@@ -295,7 +293,6 @@ apache2_setup() {
   a2enmod ssl
 
   # PHP packages that need extra setup
-  phpenmod mcrypt
   phpenmod imap
 
   # Restart Apache
@@ -362,7 +359,7 @@ mailcatcher_setup_gem() {
   cp "/srv/config/init/mailcatcher-gem.conf"  "/etc/init/mailcatcher.conf"
 
 # Make php use it to send mail
-  cp "/srv/config/php-fpm-config/mailcatcher-gem.ini" "/etc/php/7.1/mods-available/mailcatcher.ini"
+  cp "/srv/config/php-fpm-config/mailcatcher-gem.ini" "/etc/php/7.2/mods-available/mailcatcher.ini"
 # Notify php mod manager (5.5+)
   sudo phpenmod mailcatcher
 
@@ -415,11 +412,11 @@ mailcatcher_setup() {
     echo " * Copied /srv/config/init/mailcatcher.conf    to /etc/init/mailcatcher.conf"
   fi
 
-  if [[ -f "/etc/php7.1/mods-available/mailcatcher.ini" ]]; then
+  if [[ -f "/etc/php7.2/mods-available/mailcatcher.ini" ]]; then
     echo " *" Mailcatcher php7 already configured.
   else
-    cp "/srv/config/php-fpm-config/mailcatcher.ini" "/etc/php7.1/mods-available/mailcatcher.ini"
-    echo " * Copied /srv/config/php-fpm-config/mailcatcher.ini    to /etc/php7.1/mods-available/mailcatcher.ini"
+    cp "/srv/config/php-fpm-config/mailcatcher.ini" "/etc/php7.2/mods-available/mailcatcher.ini"
+    echo " * Copied /srv/config/php-fpm-config/mailcatcher.ini    to /etc/php7.2/mods-available/mailcatcher.ini"
   fi
 }
 
@@ -436,9 +433,6 @@ services_restart() {
   echo -e "\nRestart services..."
   service memcached restart
   service mailcatcher restart
-
-  # Enable PHP mcrypt module by default
-  sudo phpenmod mcrypt
 
   # Enable PHP mailcatcher sendmail settings by default
   sudo phpenmod mailcatcher

--- a/www/cividev-hosts
+++ b/www/cividev-hosts
@@ -8,11 +8,7 @@
 # automatically parsed as long as they are located in subdirectories
 # of the www/ directory.
 civi.test
-d7-46.test
 d7-master.test
-wp-46.test
 wp-master.test
-d8-46.test
 d8-master.test
-b-46.test
 b-master.test


### PR DESCRIPTION
The existing config wasn't working for me. I figured if I was going to try to get it to
work I should do it on a recent stack -hence php 7.2 + ubuntu 1804

I think this still might need some work - I got my sites up & running with it but haven't re-done
the whole thing from scratch with these changes to see if it there are still glitches